### PR TITLE
chore: add ./bootstrap into rules to reduce requirements on build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For packaging the TPM_IBM variant of the library, the IBM TSS must be installed
 on the build machine.
 
 #### Configuration
-* First `./bootstrap` has to be invoked
+
 * For each hardware configuration, a separate Debian package has to be built
 * The configuration of the trust anchor type is done by calling the
   `debian/configure` script.

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -43,6 +43,7 @@ endif
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
+	./bootstrap
 	CC="$(CC)" ./configure $(CROSSFLAG) HARDWARE=%hwname% --enable-tools --enable-static
 
 override_dh_auto_build:


### PR DESCRIPTION
The bootstrap step needs tools like libtool, autoconf, etc. These things are correctly added as Build-Depends in debian/control. But the problem is that ./bootstrap is supposed to be run before the Debian build, which means these tools must be installed beforehand. In some build environments, this might not be easy to do.
Moving it into debian/rules before configure seems to do the trick, and it's more in line with how normal Deb packages are supposed to work.