### PR TITLE
chore: add test for rust bindings to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,3 +80,22 @@ jobs:
       - name: Test [user provided keys]
         run: |
           uta_reg_test key0.bin key1.bin
+
+  test_uta_rust_bindings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build and install libuta
+        run: |
+          ./bootstrap
+          ./configure HARDWARE=UTA_SIM
+          make
+          sudo make install
+          sudo ldconfig
+      - name: Build rust bindings and run tests
+        run: |
+          cd libuta_rust
+          export LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH
+          cargo build
+          cargo test


### PR DESCRIPTION
This PR adds the CI job `test_uta_rust_bindings` doing the following steps:
* install libuta with backend UTA_SIM
* build the rust bindings
* run the test code of the rust bindings